### PR TITLE
Fix npm publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,10 @@ workflows:
   version: 2
   test-and-publish:
     jobs:
-      - test
+      - test:
+          filters:
+            tags:
+              only: /v.*/
       - publish:
           requires:
             - test


### PR DESCRIPTION
With Circle2, all jobs that the tag-only job depends on must also run
for tags. The default is to ignore tags. See:
https://circleci.com/docs/2.0/workflows/#git-tag-job-execution