### PR TITLE
correct usage example function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ const repoData = new RepoDataClient({
     apiSecret: 'xxXXXxxXXXXXXXXXxxxxxxxXXXxXxXXXXXXxxXXx'
 });
 
-const repos = await repoData.getRepos();
+const repos = await repoData.listRepos();
 ```
 
 


### PR DESCRIPTION
it was `getRepos`, which is fictional. corrected to `listRepos`