### PR TITLE
Handle errors where "response.body" does not exist.

### DIFF
--- a/docs/client.js.html
+++ b/docs/client.js.html
@@ -554,10 +554,12 @@ class RepoDataClient {
 		});
 		if (response.statusCode >= 400) {
 			let error;
-			if (response.body.validation) {
+			if (response.body &amp;&amp; response.body.validation) {
 				error = new Error(`${response.body.message}: ${response.body.validation.join(', ')}`);
-			} else {
+			} else if(response.body) {
 				error = new Error(response.body.message);
+			} else {
+				error = new Error(`Repo-data request failed with status code "${response.statusCode}".`);
 			}
 			error.status = response.statusCode;
 			throw error;

--- a/lib/client.js
+++ b/lib/client.js
@@ -513,10 +513,12 @@ class RepoDataClient {
 		});
 		if (response.statusCode >= 400) {
 			let error;
-			if (response.body.validation) {
+			if (response.body && response.body.validation) {
 				error = new Error(`${response.body.message}: ${response.body.validation.join(', ')}`);
-			} else {
+			} else if(response.body) {
 				error = new Error(response.body.message);
+			} else {
+				error = new Error(`Repo-data request failed with status code "${response.statusCode}".`);
 			}
 			error.status = response.statusCode;
 			throw error;


### PR DESCRIPTION
We are currently seeing errors `TypeError: Cannot read properties of undefined (reading 'validation')` in consuming apps, but can't replicate. This may give us a more useful error. At least the status code.